### PR TITLE
Add the giantswarm demo directory

### DIFF
--- a/giantswarm/DEMO.md
+++ b/giantswarm/DEMO.md
@@ -1,0 +1,224 @@
+# Emissary and Linkerd Resilience Patterns
+
+This is the documentation - and executable code! - for a demo of resilience
+patterns using Emissary-ingress and Linkerd. The easiest way to use this file
+is to execute it with [demosh].
+
+Things in Markdown comments are safe to ignore when reading this later. When
+executing this with [demosh], things after the horizontal rule below (which
+is just before a commented `@SHOW` directive) will get displayed.
+
+[demosh]: https://github.com/BuoyantIO/demosh
+
+When you use `demosh` to run this file, your cluster will be checked for you.
+
+<!-- set -e >
+<!-- @import ../demosh/demo-tools.sh -->
+<!-- @import ../demosh/check-requirements.sh -->
+
+<!-- @start_livecast -->
+
+---
+<!-- @SHOW -->
+
+# Linkerd Resilience Patterns
+
+We're going to show a couple of simple Linkerd resilience techniques using the
+Faces demo (from https://github.com/BuoyantIO/faces-demo):
+
+- _Retries_ automatically repeat requests that fail; and
+- _Timeouts_ cut off requests that take too long.
+
+Though both are very simple, they can be extremely effective.
+
+Let's start with a quick look at Faces in the web browser. You'll be able to
+see that it's in pretty sorry shape immediately.
+
+<!-- @wait -->
+<!-- @show_4 -->
+<!-- @wait -->
+<!-- @clear -->
+<!-- @show_composite -->
+
+By eye, we can see that this is not a well-behaving application, but we don't
+have a good way to see where the failures are, or what exactly is failing. If
+we look at the Linkerd Viz dashboard at this point, the best it can do is to
+tell us that we have workloads running, but that it can't tell us anything
+about them.
+
+<!-- @browser_then_composite -->
+
+## Enter the Mesh
+
+Let's bring Linkerd into play so that we can start answering these questions.
+
+Our browser talks to Emissary, which in turn talks to the Faces app itself, so
+let's get both Emissary and Faces into the mesh. We'll start with Emissary.
+
+<!-- @wait -->
+
+First we'll annotate the emissary namespace to tell Linkerd to include it...
+
+```bash
+kubectl annotate ns emissary linkerd.io/inject=enabled
+```
+
+...then, we need to restart Emissary's deployments.
+
+```bash
+kubectl rollout restart -n emissary deployment
+kubectl rollout status -n emissary deployment
+```
+
+At this point, a look at the Linkerd Viz dashboard will show that Emissary's
+pods are meshed.
+
+<!-- @browser_then_composite -->
+
+Next, we'll repeat that process for the Faces namespace.
+
+```bash
+kubectl annotate ns faces linkerd.io/inject=enabled
+kubectl rollout restart -n faces deployment
+kubectl rollout status -n faces deployment
+```
+
+If we look at Linkerd Viz now, it can immediately show us that the Faces
+application is now meshed. Given a few seconds, it'll be able to give us some
+hard data about what's going wrong, and about how bad things are.
+
+<!-- @browser_then_composite -->
+
+## Retries
+
+Let's start by going after the red frowning faces: those are the ones where
+the face service itself is failing. We'll tell Linkerd that it's OK to retry
+connections to the face service, by adding a ServiceProfile resource:
+
+```bash
+bat k8s/02-retries/face-profile.yaml
+```
+
+Linkerd uses a _retry budget_: it computes how much of the total traffic it's
+sending to a workload is retries, and as long as that fraction doesn't exceed
+the retry budget (20% by default), Linkerd will just keep retrying. Let's
+apply that and see what happens.
+
+```bash
+kubectl apply -f k8s/02-retries/face-profile.yaml
+```
+
+<!-- @wait_clear -->
+
+So that helped quite a bit! Let's continue by adding a retry for the smiley
+service, too, to try to get rid of the cursing faces:
+
+```bash
+bat k8s/02-retries/smiley-profile.yaml
+kubectl apply -f k8s/02-retries/smiley-profile.yaml
+```
+
+<!-- @wait_clear -->
+
+We can do the same for the color service, to get rid of the grey backgrounds.
+
+```bash
+bat k8s/02-retries/color-profile.yaml
+kubectl apply -f k8s/02-retries/color-profile.yaml
+```
+
+<!-- @wait_clear -->
+
+Note that if we head back to the Viz dashboard, we'll still see the real
+success rate, _without_ factoring in the effect of the retries.
+
+<!-- @browser_then_composite -->
+
+If we really want to see the effective success rate, we can use the `linkerd
+viz routes` command. Here, we'll check the difference between the real and
+effective success rates for traffic from the `face` Deployment to the `smiley`
+Deployment:
+
+```bash
+linkerd viz routes -o wide -n faces deploy/face --to deploy/smiley
+```
+
+<!-- @show_terminal -->
+
+Note that we see both the real and effective success rates, _and_ the real and
+effective request rate. You can clearly see that retries actually _increase_
+the load on the services, since they cause more requests: they're not about
+protecting the service, they're about **improving the experience of the
+client**.
+
+<!-- @wait_clear -->
+<!-- @show_composite -->
+
+## Timeouts
+
+Things are a lot better already! but... still too slow, which we can see as
+those cells that are fading away. Let's add some timeouts, starting from the
+bottom of the call graph this time.
+
+Again, timeouts are not about protecting the service: they are about
+**providing agency to the client** by giving the client a chance to decide
+what to do when things take too long. In fact, like retries, they _increase_
+the load on the service.
+
+We'll start by adding a timeout to the color service. This timeout will give
+agency to the face service, as the client of the color service: when a call to
+the color service takes too long, the face service will show a pink background
+for that cell.
+
+```bash
+diff -u99 --color k8s/{02-retries,03-timeouts}/color-profile.yaml
+```
+
+Let's apply that and see how things go.
+
+```bash
+kubectl apply -f k8s/03-timeouts/color-profile.yaml
+```
+
+<!-- @wait_clear -->
+
+Let's continue by adding a timout to the smiley service. The face service
+will show a smiley-service timeout as a sleeping face.
+
+```bash
+diff -u99 --color k8s/{02-retries,03-timeouts}/smiley-profile.yaml
+kubectl apply -f k8s/03-timeouts/smiley-profile.yaml
+```
+
+<!-- @wait_clear -->
+
+Finally, we'll add a timeout that lets the GUI decide what to do if the face
+service itself takes too long.
+
+When the GUI sees a timeout talking to the face service, it will just keep
+showing the user the old data for awhile. There are a lot of applications
+where this makes an enormous amount of sense: if you can't get updated data,
+the most recent data may still be valuable for some time! Eventually, though,
+the app should really show the user that something is wrong: in our GUI,
+repeated timeouts eventually lead to a faded sleeping-face cell with a pink
+background.
+
+For the moment, too, the GUI will show a counter of timed-out attempts, to
+make it a little more clear what's going on.
+
+```bash
+diff -u99 --color k8s/{02-retries,03-timeouts}/face-profile.yaml
+kubectl apply -f k8s/03-timeouts/face-profile.yaml
+```
+
+<!-- @wait_clear -->
+
+# SUMMARY
+
+We've used Linkerd to take a very, very broken application and turn it into
+something the user might actually have an OK experience with. Fixing the
+application is, of course, still necessary!! but making the user experience
+better is a good thing.
+
+<!-- @wait -->
+<!-- @show_slides -->

--- a/giantswarm/DEMO.md
+++ b/giantswarm/DEMO.md
@@ -1,8 +1,8 @@
-# Emissary and Linkerd Resilience Patterns
+# Linkerd Resilience Patterns on Giant Swarm
 
 This is the documentation - and executable code! - for a demo of resilience
-patterns using Emissary-ingress and Linkerd. The easiest way to use this file
-is to execute it with [demosh].
+patterns using Linkerd running on a Giant Swarm cluster. The easiest way to
+use this file is to execute it with [demosh].
 
 Things in Markdown comments are safe to ignore when reading this later. When
 executing this with [demosh], things after the horizontal rule below (which

--- a/giantswarm/emissary-yaml/linkerd-viz-mapping.yaml
+++ b/giantswarm/emissary-yaml/linkerd-viz-mapping.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: viz-example-mapping
+spec:
+  prefix: /
+  hostname: "*"
+  service: web.linkerd-viz.svc.cluster.local:8084
+  host_rewrite: web.linkerd-viz.svc.cluster.local:8084
+  remove_request_headers:
+  - Origin
+  allow_upgrade:
+  - websocket

--- a/giantswarm/emissary-yaml/listeners-and-hosts.yaml
+++ b/giantswarm/emissary-yaml/listeners-and-hosts.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Listener
+metadata:
+  name: ambassador-https-listener
+spec:
+  port: 8443
+  protocol: HTTPS
+  securityModel: XFP
+  hostBinding:
+    namespace:
+      from: ALL
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Listener
+metadata:
+  name: ambassador-http-listener
+spec:
+  port: 8080
+  protocol: HTTP
+  securityModel: XFP
+  hostBinding:
+    namespace:
+      from: ALL
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: wildcard-host
+spec:
+  hostname: "*"
+  requestPolicy:
+    insecure:
+      action: Route

--- a/giantswarm/k8s/01-base/color-mapping.yaml
+++ b/giantswarm/k8s/01-base/color-mapping.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: color-mapping
+  namespace: faces
+spec:
+  hostname: "*"
+  prefix: /color/
+  service: color.faces
+  timeout_ms: 0

--- a/giantswarm/k8s/01-base/face-mapping.yaml
+++ b/giantswarm/k8s/01-base/face-mapping.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: face-mapping
+  namespace: faces
+spec:
+  hostname: "*"
+  prefix: /face/
+  service: face.faces
+  timeout_ms: 0

--- a/giantswarm/k8s/01-base/faces-gui-mapping.yaml
+++ b/giantswarm/k8s/01-base/faces-gui-mapping.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: gui-mapping
+  namespace: faces
+spec:
+  hostname: "*"
+  prefix: /faces/
+  service: faces-gui.faces
+  rewrite: /
+  timeout_ms: 0

--- a/giantswarm/k8s/01-base/faces-gui.yaml
+++ b/giantswarm/k8s/01-base/faces-gui.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: faces-gui
+  namespace: faces
+spec:
+  type: ClusterIP
+  selector:
+    service: faces-gui
+  ports:
+  - port: 80
+    targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: faces-gui
+  namespace: faces
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: faces-gui
+  template:
+    metadata:
+      labels:
+        service: faces-gui
+    spec:
+      containers:
+      - name: faces-gui
+        image: dwflynn/faces-gui:0.6.1
+        imagePullPolicy: Always
+        ports:
+        - name: http
+          containerPort: 8000
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi

--- a/giantswarm/k8s/01-base/faces.yaml
+++ b/giantswarm/k8s/01-base/faces.yaml
@@ -1,0 +1,150 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: face
+  namespace: faces
+spec:
+  type: ClusterIP
+  selector:
+    service: face
+  ports:
+  - port: 80
+    targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: face
+  namespace: faces
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: face
+  template:
+    metadata:
+      labels:
+        service: face
+    spec:
+      containers:
+      - name: face
+        image: dwflynn/faces-service:0.6.1
+        imagePullPolicy: Always
+        ports:
+        - name: http
+          containerPort: 8000
+        env:
+        - name: FACES_SERVICE
+          value: "face"
+        - name: ERROR_FRACTION
+          value: "20"
+        # - name: DELAY_BUCKETS
+        #   value: "0,5,10,15,20,50,200,500,1500"
+        resources:
+          requests:
+            cpu: 300m     # The face service doesn't need much memory, but it does need more
+            memory: 64Mi  # CPU than the other backend services since it has to call the
+          limits:         # face and smiley services, then composite the results.
+            cpu: 500m
+            memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: smiley
+  namespace: faces
+spec:
+  type: ClusterIP
+  selector:
+    service: smiley
+  ports:
+  - port: 80
+    targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: smiley
+  namespace: faces
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: smiley
+  template:
+    metadata:
+      labels:
+        service: smiley
+    spec:
+      containers:
+      - name: smiley
+        image: dwflynn/faces-service:0.6.1
+        imagePullPolicy: Always
+        ports:
+        - name: http
+          containerPort: 8000
+        env:
+        - name: FACES_SERVICE
+          value: "smiley"
+        - name: ERROR_FRACTION
+          value: "20"
+        - name: DELAY_BUCKETS
+          value: "0,5,10,15,20,50,200,500,1500"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+          limits:
+            cpu: 250m
+            memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: color
+  namespace: faces
+spec:
+  type: ClusterIP
+  selector:
+    service: color
+  ports:
+  - port: 80
+    targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: color
+  namespace: faces
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: color
+  template:
+    metadata:
+      labels:
+        service: color
+    spec:
+      containers:
+      - name: color
+        image: dwflynn/faces-service:0.6.1
+        imagePullPolicy: Always
+        ports:
+        - name: http
+          containerPort: 8000
+        env:
+        - name: FACES_SERVICE
+          value: "color"
+        - name: ERROR_FRACTION
+          value: "20"
+        - name: DELAY_BUCKETS
+          value: "0,5,10,15,20,50,200,500,1500"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+          limits:
+            cpu: 250m
+            memory: 128Mi

--- a/giantswarm/k8s/01-base/smiley-mapping.yaml
+++ b/giantswarm/k8s/01-base/smiley-mapping.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: smiley-mapping
+  namespace: faces
+spec:
+  hostname: "*"
+  prefix: /smiley/
+  service: smiley.faces
+  timeout_ms: 0

--- a/giantswarm/k8s/02-profiles/color-profile.yaml
+++ b/giantswarm/k8s/02-profiles/color-profile.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  creationTimestamp: null
+  name: color.faces.svc.cluster.local
+  namespace: faces
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /
+    name: GET /

--- a/giantswarm/k8s/02-profiles/face-profile.yaml
+++ b/giantswarm/k8s/02-profiles/face-profile.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  creationTimestamp: null
+  name: face.faces.svc.cluster.local
+  namespace: faces
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /
+    name: GET /

--- a/giantswarm/k8s/02-profiles/smiley-profile.yaml
+++ b/giantswarm/k8s/02-profiles/smiley-profile.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  creationTimestamp: null
+  name: smiley.faces.svc.cluster.local
+  namespace: faces
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /
+    name: GET /

--- a/giantswarm/k8s/02-retries/color-profile.yaml
+++ b/giantswarm/k8s/02-retries/color-profile.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: color.faces.svc.cluster.local
+  namespace: faces
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /.*
+    name: GET /
+    isRetryable: true

--- a/giantswarm/k8s/02-retries/face-profile.yaml
+++ b/giantswarm/k8s/02-retries/face-profile.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: face.faces.svc.cluster.local
+  namespace: faces
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /.*
+    name: GET /
+    isRetryable: true

--- a/giantswarm/k8s/02-retries/smiley-profile.yaml
+++ b/giantswarm/k8s/02-retries/smiley-profile.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: smiley.faces.svc.cluster.local
+  namespace: faces
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /.*
+    name: GET /
+    isRetryable: true

--- a/giantswarm/k8s/03-timeouts/color-profile.yaml
+++ b/giantswarm/k8s/03-timeouts/color-profile.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: color.faces.svc.cluster.local
+  namespace: faces
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /.*
+    name: GET /
+    isRetryable: true
+    timeout: 300ms

--- a/giantswarm/k8s/03-timeouts/face-profile.yaml
+++ b/giantswarm/k8s/03-timeouts/face-profile.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: face.faces.svc.cluster.local
+  namespace: faces
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /.*
+    name: GET /
+    isRetryable: true
+    timeout: 250ms

--- a/giantswarm/k8s/03-timeouts/smiley-profile.yaml
+++ b/giantswarm/k8s/03-timeouts/smiley-profile.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: smiley.faces.svc.cluster.local
+  namespace: faces
+spec:
+  routes:
+  - condition:
+      method: GET
+      pathRegex: /.*
+    name: GET /
+    isRetryable: true
+    timeout: 300ms

--- a/giantswarm/setup-cluster.sh
+++ b/giantswarm/setup-cluster.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: 2022 Buoyant Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2022 Buoyant Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+clear
+
+# Make sure that we're in the namespace we expect.
+kubectl ns default
+
+# Tell demosh to show commands as they're run.
+#@SHOW
+
+# Next up: install Emissary-ingress 3.5.0 as the ingress. This is mostly following
+# the quickstart, but we use `yq` to delete the downwardAPI volume and volumeMount
+# since Giant Swarm disables that. (This means, in turn, that we can't use Ingress
+# resources, which we're not using anyway.)
+#
+# We install this unmeshed for the moment.
+
+#### EMISSARY_INSTALL_START
+EMISSARY_CRDS=https://app.getambassador.io/yaml/emissary/3.5.0/emissary-crds.yaml
+EMISSARY_INGRESS=https://app.getambassador.io/yaml/emissary/3.5.0/emissary-emissaryns.yaml
+
+kubectl create namespace emissary && \
+curl --proto '=https' --tlsv1.2 -sSfL $EMISSARY_CRDS | kubectl apply -f -
+kubectl wait --timeout=90s --for=condition=available deployment emissary-apiext -n emissary-system
+
+curl --proto '=https' --tlsv1.2 -sSfL $EMISSARY_INGRESS \
+    | yq 'del(.spec.template.spec.containers.[].volumeMounts)' \
+    | yq 'del(.spec.template.spec.volumes)' \
+    | kubectl apply -f -
+
+kubectl -n emissary wait --for condition=available --timeout=90s deploy -lproduct=aes
+#### EMISSARY_INSTALL_END
+
+#@wait
+#@clear
+
+# Finally, configure Emissary for HTTP - not HTTPS! - routing to our cluster.
+#### EMISSARY_CONFIGURE_START
+kubectl apply -f emissary-yaml
+#### EMISSARY_CONFIGURE_END
+
+#@wait
+#@clear
+# Once that's done, install Faces. We also do this without the mesh at first, so
+# no ServiceProfiles, but we'll install its Mappings.
+
+#### FACES_INSTALL_START
+kubectl create ns faces
+
+kubectl apply -f k8s/01-base
+kubectl -n faces wait --for condition=available --timeout=90s deploy --all
+
+#### FACES_INSTALL_END


### PR DESCRIPTION
The `giantswarm` directory has (largely duplicated 🙁) files to run a demo on a Giant Swarm cluster. This will get folded into the main demo later. Changes:

- We delete Emissary's `downwardAPI` mount when installing Emissary, since Giant Swarm doesn't allow such mounts.
- We only show retries and timeouts, since
- We use Linkerd for all the resilience things (partly to show that it's possible, partly because the webinar we used this demo for focused on Linkerd 🙂).