### PR TITLE
Chart improvements

### DIFF
--- a/assets/html/index.html
+++ b/assets/html/index.html
@@ -876,20 +876,25 @@ class Cell {
 class Key {
 	constructor(keyDiv) {
 		let keyEntries = [
-			[ "smiling",  "green", "grey", "24px", "Success!" ],
-			[ "confused", "red",   "grey", "",     "Face service error" ],
-			[ "sleeping", "pink",  "grey", "",     "Timeout" ],
-			[ "kaboom",   "red",   "grey", "24px", "Service overwhelmed" ],
-			[ "smiling",  "grey",  "red",  "",     "Color service error" ],
-			[ "cursing",  "green", "red",  "24px", "Smiley service error" ],
-			[ "-",        "-",     "-",    "",     "Slow service" ]
+			[ "smiling",  "blue",  "grey",         "24px", "Success!" ],
+			[ "confused", "red",   "grey",         "",     "Face service error" ],
+			[ "sleeping", "pink",  "grey",         "",     "Timeout" ],
+			[ "kaboom",   "red",   "grey",         "24px", "Service overwhelmed" ],
+			[ "smiling",  "grey",  "transparent",  "",     "Color service error" ],
+			[ "",         "blue",  "red",          "24px", "Smiley service error" ],
+			[ "-",         "-",     "-",           "",     "Slow service" ]
 		]
 
 		for (let i = 0; i < keyEntries.length; i++) {
 			let [ smileyName, bgColor, borderColor, margin, text ] = keyEntries[i]
 
 			if (smileyName != "-") {
-				let smiley = Cell.smilies[smileyName]
+				let smiley = ""
+
+				if (smileyName != "") {
+					smiley = Cell.smilies[smileyName]
+				}
+
 				let style = `background: ${bgColor}; border: 2px solid ${borderColor};`
 
 				if (margin) {

--- a/faces-chart/templates/_helpers.tpl
+++ b/faces-chart/templates/_helpers.tpl
@@ -107,6 +107,22 @@
   {{- include "partials.select-errorFraction" (dict "source" .Values.color "default" .Values.backend) -}}
 {{- end -}}
 
+{{- define "partials.color2-image" -}}
+  {{- include "partials.select-image" (dict "source" .Values.color2 "default" .Values.backend "root" .) -}}
+{{- end -}}
+
+{{- define "partials.color2-imagePullPolicy" -}}
+  {{- include "partials.select-imagePullPolicy" (dict "source" .Values.color2 "default" .Values.backend "root" .) -}}
+{{- end -}}
+
+{{- define "partials.color2-delayBuckets" -}}
+  {{- include "partials.select-delayBuckets" (dict "source" .Values.color2 "default" .Values.backend) -}}
+{{- end -}}
+
+{{- define "partials.color2-errorFraction" -}}
+  {{- include "partials.select-errorFraction" (dict "source" .Values.color2 "default" .Values.backend) -}}
+{{- end -}}
+
 {{- define "partials.smiley-image" -}}
   {{- include "partials.select-image" (dict "source" .Values.smiley "default" .Values.backend "root" .) -}}
 {{- end -}}
@@ -123,3 +139,18 @@
   {{- include "partials.select-errorFraction" (dict "source" .Values.smiley "default" .Values.backend) -}}
 {{- end -}}
 
+{{- define "partials.smiley2-image" -}}
+  {{- include "partials.select-image" (dict "source" .Values.smiley2 "default" .Values.backend "root" .) -}}
+{{- end -}}
+
+{{- define "partials.smiley2-imagePullPolicy" -}}
+  {{- include "partials.select-imagePullPolicy" (dict "source" .Values.smiley2 "default" .Values.backend "root" .) -}}
+{{- end -}}
+
+{{- define "partials.smiley2-delayBuckets" -}}
+  {{- include "partials.select-delayBuckets" (dict "source" .Values.smiley2 "default" .Values.backend) -}}
+{{- end -}}
+
+{{- define "partials.smiley2-errorFraction" -}}
+  {{- include "partials.select-errorFraction" (dict "source" .Values.smiley2 "default" .Values.backend) -}}
+{{- end -}}

--- a/faces-chart/templates/color.yaml
+++ b/faces-chart/templates/color.yaml
@@ -37,6 +37,8 @@ spec:
         env:
         - name: FACES_SERVICE
           value: "color"
+        - name: COLOR
+          value: {{ .Values.color.color }}
         {{- include "partials.color-errorFraction" . }}
         {{- include "partials.color-delayBuckets" . }}
         resources:

--- a/faces-chart/templates/color2.yaml
+++ b/faces-chart/templates/color2.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.color2.enabled -}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: color2
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: ClusterIP
+  selector:
+    service: color2
+  ports:
+  - port: 80
+    targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: color2
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: color2
+  template:
+    metadata:
+      labels:
+        service: color2
+    spec:
+      containers:
+      - name: color2
+        image: {{ include "partials.color2-image" . }}
+        imagePullPolicy: {{ include "partials.color2-imagePullPolicy" . }}
+        ports:
+        - name: http
+          containerPort: 8000
+        env:
+        - name: FACES_SERVICE
+          value: "color"
+        - name: COLOR
+          value: {{ .Values.color2.color }}
+        {{- include "partials.color2-errorFraction" . }}
+        {{- include "partials.color2-delayBuckets" . }}
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+          limits:
+            cpu: 250m
+            memory: 128Mi
+{{- end -}}

--- a/faces-chart/templates/smiley.yaml
+++ b/faces-chart/templates/smiley.yaml
@@ -37,6 +37,8 @@ spec:
         env:
         - name: FACES_SERVICE
           value: "smiley"
+        - name: SMILEY
+          value: {{ .Values.smiley.smiley }}
         {{- include "partials.smiley-errorFraction" . }}
         {{- include "partials.smiley-delayBuckets" . }}
         resources:

--- a/faces-chart/templates/smiley2.yaml
+++ b/faces-chart/templates/smiley2.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.smiley2.enabled -}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: smiley2
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: ClusterIP
+  selector:
+    service: smiley2
+  ports:
+  - port: 80
+    targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: smiley2
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: smiley2
+  template:
+    metadata:
+      labels:
+        service: smiley2
+    spec:
+      containers:
+      - name: smiley2
+        image: {{ include "partials.smiley2-image" . }}
+        imagePullPolicy: {{ include "partials.smiley2-imagePullPolicy" . }}
+        ports:
+        - name: http
+          containerPort: 8000
+        env:
+        - name: FACES_SERVICE
+          value: "smiley"
+        - name: SMILEY
+          value: {{ .Values.smiley2.smiley }}
+        {{- include "partials.smiley2-errorFraction" . }}
+        {{- include "partials.smiley2-delayBuckets" . }}
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+          limits:
+            cpu: 250m
+            memory: 128Mi
+{{ end }}

--- a/faces-chart/values.yaml
+++ b/faces-chart/values.yaml
@@ -39,6 +39,7 @@ smiley:
   imagePullPolicy: ""           # If not set, uses backend.imagePullPolicy
   errorFraction: ""             # If not set, uses backend.errorFraction
   delayBuckets: ""              # If not set, uses backend.delayBuckets
+  smiley: "Smiling"             # Override if desired
 
 color:
   image: ""                     # If set, overrides the imageName/imageTag pair
@@ -47,3 +48,4 @@ color:
   imagePullPolicy: ""           # If not set, uses backend.imagePullPolicy
   errorFraction: ""             # If not set, uses backend.errorFraction
   delayBuckets: ""              # If not set, uses backend.delayBuckets
+  color: "blue"                 # Override if desired

--- a/faces-chart/values.yaml
+++ b/faces-chart/values.yaml
@@ -41,6 +41,16 @@ smiley:
   delayBuckets: ""              # If not set, uses backend.delayBuckets
   smiley: "Smiling"             # Override if desired
 
+smiley2:
+  enabled: False                # If set to True, enables the second smiley workload
+  image: ""                     # If set, overrides the imageName/imageTag pair
+  imageName: ""                 # If not set, uses backend.imageName
+  imageTag: ""                  # If not set, uses backend.imageTag
+  imagePullPolicy: ""           # If not set, uses backend.imagePullPolicy
+  errorFraction: ""             # If not set, uses backend.errorFraction
+  delayBuckets: ""              # If not set, uses backend.delayBuckets
+  smiley: "HeartEyes"           # Override if desired
+
 color:
   image: ""                     # If set, overrides the imageName/imageTag pair
   imageName: ""                 # If not set, uses backend.imageName
@@ -49,3 +59,13 @@ color:
   errorFraction: ""             # If not set, uses backend.errorFraction
   delayBuckets: ""              # If not set, uses backend.delayBuckets
   color: "blue"                 # Override if desired
+
+color2:
+  enabled: False                # If set to True, enables the second color workload
+  image: ""                     # If set, overrides the imageName/imageTag pair
+  imageName: ""                 # If not set, uses backend.imageName
+  imageTag: ""                  # If not set, uses backend.imageTag
+  imagePullPolicy: ""           # If not set, uses backend.imagePullPolicy
+  errorFraction: ""             # If not set, uses backend.errorFraction
+  delayBuckets: ""              # If not set, uses backend.delayBuckets
+  color: "orange"               # Override if desired

--- a/faces-chart/values.yaml
+++ b/faces-chart/values.yaml
@@ -7,7 +7,7 @@
 defaultImageTag: ""             # If not set, uses the appVersion
 
 # Default imagePullPolicy. This is used only if not set in the sections below.
-defaultImagePullPolicy: Always
+defaultImagePullPolicy: IfNotPresent
 
 gui:
   image: ""                     # If set, overrides the imageName/imageTag pair


### PR DESCRIPTION
Default color to blue rather than green -- using blue/orange is (hopefully?) better
in case of red-green colorblindness.

Allow setting the color & smiley in the Helm chart.

Support having the Helm chart install smiley2 & color2. If enabled, smiley2 defaults
to HeartEyes and color2 defaults to orange.
