### PR TITLE
Support for the BEL autoregistration harness

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -254,6 +254,24 @@ docker_manifests:
     push_flags:
       - --insecure
 
+  - name_template: "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}-bel-external-workload:latest"
+    image_templates:
+      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}-bel-external-workload:latest-arm64"
+      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}-bel-external-workload:latest-amd64"
+    create_flags:
+      - --insecure
+    push_flags:
+      - --insecure
+
+  - name_template: "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}-bel-external-workload:{{ .Version }}"
+    image_templates:
+      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}-bel-external-workload:{{ .Version }}-arm64"
+      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}-bel-external-workload:{{ .Version }}-amd64"
+    create_flags:
+      - --insecure
+    push_flags:
+      - --insecure
+
 archives:
   - id: generic
     name_template: '{{ .ProjectName }}_generic_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,6 +25,8 @@ version: 1
 env:
   - REGISTRY={{ if index .Env "REGISTRY"  }}{{ .Env.REGISTRY }}{{ else }}ghcr.io/buoyantio{{ end }}
   - IMAGE_NAME={{ if index .Env "IMAGE_NAME"  }}{{ .Env.IMAGE_NAME }}{{ else }}faces{{ end }}
+  - EXTERNAL_BASE={{ if index .Env "EXTERNAL_BASE"  }}{{ .Env.EXTERNAL_BASE }}{{ else }}ghcr.io/buoyantio/demo-external-base:0.3.0{{ end }}
+  - BEL_EXTERNAL_BASE={{ if index .Env "BEL_EXTERNAL_BASE"  }}{{ .Env.BEL_EXTERNAL_BASE }}{{ else }}ghcr.io/buoyantio/demo-bel-external-base:0.3.0{{ end }}
 
 before:
   hooks:
@@ -121,6 +123,7 @@ dockers:
       - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}-external-workload:latest-arm64"
     build_flag_templates:
       - "--platform=linux/arm64"
+      - "--build-arg=EXTERNAL_BASE={{ .Env.EXTERNAL_BASE }}"
   - use: buildx
     goos: linux
     goarch: amd64
@@ -132,6 +135,31 @@ dockers:
       - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}-external-workload:latest-amd64"
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--build-arg=EXTERNAL_BASE={{ .Env.EXTERNAL_BASE }}"
+  - use: buildx
+    goos: linux
+    goarch: arm64
+    dockerfile: Dockerfiles/Dockerfile.bel-external-workload
+    ids:
+      - generic
+    image_templates:
+      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}-bel-external-workload:{{ .Version }}-arm64"
+      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}-bel-external-workload:latest-arm64"
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--build-arg=EXTERNAL_BASE={{ .Env.BEL_EXTERNAL_BASE }}"
+  - use: buildx
+    goos: linux
+    goarch: amd64
+    dockerfile: Dockerfiles/Dockerfile.bel-external-workload
+    ids:
+      - generic
+    image_templates:
+      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}-bel-external-workload:{{ .Version }}-amd64"
+      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}-bel-external-workload:latest-amd64"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--build-arg=EXTERNAL_BASE={{ .Env.BEL_EXTERNAL_BASE }}"
 
   # For the Pi, we only build an external-workload image for arm64. The Pi itself
   # is arm64, so there's no point in building for amd64, and we're not going to try
@@ -152,6 +180,24 @@ dockers:
       - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}-pi-workload:latest"
     build_flag_templates:
       - "--platform=linux/arm64"
+      - "--build-arg=EXTERNAL_BASE={{ .Env.EXTERNAL_BASE }}"
+  - use: buildx
+    goos: linux
+    goarch: arm64
+    # Not a typo! We really do use the same Dockerfile as the generic external
+    # workload, we're just copying in our workload binary from the Pi build
+    # rather than the generic build.
+    dockerfile: Dockerfiles/Dockerfile.bel-external-workload
+    ids:
+      - pi
+    image_templates:
+      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}-bel-pi-workload:{{ .Version }}-arm64"
+      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}-bel-pi-workload:latest-arm64"
+      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}-bel-pi-workload:{{ .Version }}"
+      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}-bel-pi-workload:latest"
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--build-arg=EXTERNAL_BASE={{ .Env.BEL_EXTERNAL_BASE }}"
 
 docker_manifests:
   - name_template: "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}-gui:{{ .Version }}"

--- a/Dockerfiles/Dockerfile.bel-external-workload
+++ b/Dockerfiles/Dockerfile.bel-external-workload
@@ -26,4 +26,4 @@ FROM $EXTERNAL_BASE AS final
 LABEL org.opencontainers.image.source=https://github.com/BuoyantIO/faces-demo
 
 # Copy the compiled binary from the builder stage into the final image
-COPY workload /workload/start
+COPY --chmod=0755 workload /workload/start

--- a/pkg/faces/baseserver.go
+++ b/pkg/faces/baseserver.go
@@ -153,6 +153,7 @@ func (srv *BaseServer) SetupFromEnvironment() {
 	}
 
 	srv.RegisterCustom("/rl", srv.rlGetHandler)
+	srv.RegisterCustom("/ready", srv.readyHandler)
 
 	srv.userHeaderName = utils.StringFromEnv("USER_HEADER_NAME", "X-Faces-User")
 	srv.hostIP = utils.StringFromEnv("HOST_IP", utils.StringFromEnv("HOSTNAME", "unknown"))
@@ -346,6 +347,15 @@ func (srv *BaseServer) rlGetHandler(w http.ResponseWriter, r *http.Request) {
 		StatusCode: http.StatusOK,
 		Data: map[string]interface{}{
 			"rl": rateStr,
+		},
+	})
+}
+
+func (srv *BaseServer) readyHandler(w http.ResponseWriter, r *http.Request) {
+	srv.StandardResponse(w, r, &BaseServerResponse{
+		StatusCode: http.StatusOK,
+		Data: map[string]interface{}{
+			"ready": true,
 		},
 	})
 }


### PR DESCRIPTION
Add a BEL external-workload image. Also rev the baseserver to support
a probe endpoint, /ready.

- **Build images to work with the BEL autoregistration harness**
- **Oops. Add the bel-external-workload manifests**
