### PR TITLE
Add labels to `service` and `deployment` types

### DIFF
--- a/faces-chart/templates/color.yaml
+++ b/faces-chart/templates/color.yaml
@@ -4,6 +4,8 @@ kind: Service
 metadata:
   name: color
   namespace: {{ .Release.Namespace }}
+  labels:
+    service: color
 spec:
   type: ClusterIP
   selector:
@@ -17,6 +19,8 @@ kind: Deployment
 metadata:
   name: color
   namespace: {{ .Release.Namespace }}
+  labels:
+    service: color
 spec:
   replicas: 1
   selector:

--- a/faces-chart/templates/color2.yaml
+++ b/faces-chart/templates/color2.yaml
@@ -5,6 +5,8 @@ kind: Service
 metadata:
   name: color2
   namespace: {{ .Release.Namespace }}
+  labels:
+    service: color2
 spec:
   type: ClusterIP
   selector:
@@ -18,6 +20,8 @@ kind: Deployment
 metadata:
   name: color2
   namespace: {{ .Release.Namespace }}
+  labels:
+    service: color2
 spec:
   replicas: 1
   selector:

--- a/faces-chart/templates/face.yaml
+++ b/faces-chart/templates/face.yaml
@@ -4,6 +4,8 @@ kind: Service
 metadata:
   name: face
   namespace: {{ .Release.Namespace }}
+  labels:
+    service: face
 spec:
   type: ClusterIP
   selector:
@@ -17,6 +19,8 @@ kind: Deployment
 metadata:
   name: face
   namespace: {{ .Release.Namespace }}
+  labels:
+    service: face
 spec:
   replicas: 1
   selector:

--- a/faces-chart/templates/faces-gui.yaml
+++ b/faces-chart/templates/faces-gui.yaml
@@ -4,6 +4,8 @@ kind: Service
 metadata:
   name: faces-gui
   namespace: {{ .Release.Namespace }}
+  labels:
+    service: faces-gui
 spec:
   type: {{ .Values.gui.serviceType }}
   selector:
@@ -17,6 +19,8 @@ kind: Deployment
 metadata:
   name: faces-gui
   namespace: {{ .Release.Namespace }}
+  labels:
+    service: faces-gui
 spec:
   replicas: 1
   selector:

--- a/faces-chart/templates/smiley.yaml
+++ b/faces-chart/templates/smiley.yaml
@@ -4,6 +4,8 @@ kind: Service
 metadata:
   name: smiley
   namespace: {{ .Release.Namespace }}
+  labels:
+    service: smiley
 spec:
   type: ClusterIP
   selector:
@@ -17,6 +19,8 @@ kind: Deployment
 metadata:
   name: smiley
   namespace: {{ .Release.Namespace }}
+  labels:
+    service: smiley
 spec:
   replicas: 1
   selector:

--- a/faces-chart/templates/smiley2.yaml
+++ b/faces-chart/templates/smiley2.yaml
@@ -5,6 +5,8 @@ kind: Service
 metadata:
   name: smiley2
   namespace: {{ .Release.Namespace }}
+  labels:
+    service: smiley2
 spec:
   type: ClusterIP
   selector:
@@ -18,6 +20,8 @@ kind: Deployment
 metadata:
   name: smiley2
   namespace: {{ .Release.Namespace }}
+  labels:
+    service: smiley2
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
This adds the same labels as the `pod` gets to both the `Deployment` and `Service` for each of the manifests.

Makes it easier to do `kubectl get all -l service=color`

<img width="584" alt="image" src="https://github.com/BuoyantIO/faces-demo/assets/3645856/3bebbbc2-3734-4168-93f5-2ed8f43bd678">