### PR TITLE
Make requests include /center/ or /edge/ depending on which cell is in play.

### DIFF
--- a/assets/html/index.html
+++ b/assets/html/index.html
@@ -1259,7 +1259,10 @@ window.onload = () => {
 
 	for (row = 0; row < 4; row++) {
 		for (col = 0; col < 4; col++) {
-			let cell = new Cell(logger, sw, podSet, `../face/cell/`, $("cells"), row, col)
+			let isCenter = ((row === 1 || row === 2) && (col === 1 || col === 2))
+			let cellURL = isCenter ? `../face/center/` : `../face/edge/`
+
+			let cell = new Cell(logger, sw, podSet, cellURL, $("cells"), row, col)
 			cells.push(cell)
 		}
 		$("cells").innerHTML += "<br/>"


### PR DESCRIPTION
(The point here is to allow for more meaningful routing of requests with HTTPRoutes.)

Signed-off-by: Flynn <flynn@buoyant.io>
