### PR TITLE
GPIO update

### DIFF
--- a/cmd/pi/color/main.go
+++ b/cmd/pi/color/main.go
@@ -53,6 +53,7 @@ func main() {
 	flag.Parse()
 
 	cprv := faces.NewColorProviderFromEnvironment()
+	cprv.SetUpdater(hw.Updater)
 	cprv.SetPreHook(hw.PreHook)
 	cprv.SetPostHook(hw.PostHook)
 

--- a/cmd/pi/smiley/main.go
+++ b/cmd/pi/smiley/main.go
@@ -50,6 +50,7 @@ func main() {
 	flag.Parse()
 
 	sprv := faces.NewSmileyProviderFromEnvironment()
+	sprv.SetUpdater(hw.Updater)
 	sprv.SetPreHook(hw.PreHook)
 	sprv.SetPostHook(hw.PostHook)
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.3
 
 require (
 	github.com/prometheus/client_golang v1.21.1
-	github.com/warthog618/gpiod v0.8.3
+	github.com/warthog618/go-gpiocdev v0.9.0
 	google.golang.org/grpc v1.71.0
 	google.golang.org/protobuf v1.36.5
 )

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.3
 
 require (
 	github.com/prometheus/client_golang v1.21.1
-	github.com/warthog618/go-gpiocdev v0.9.0
+	github.com/warthog618/go-gpiocdev v0.9.1
 	google.golang.org/grpc v1.71.0
 	google.golang.org/protobuf v1.36.5
 )

--- a/go.sum
+++ b/go.sum
@@ -34,10 +34,10 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/warthog618/go-gpiocdev v0.9.0 h1:AZWUq1WObgKCO9cJCACFpwWQw6yu8vJbIE6fRZ+6cbY=
+github.com/warthog618/go-gpiocdev v0.9.0/go.mod h1:GV4NZC82fWJERqk7Gu0+KfLSDIBEDNm6aPGiHlmT5fY=
 github.com/warthog618/go-gpiosim v0.1.0 h1:2rTMTcKUVZxpUuvRKsagnKAbKpd3Bwffp87xywEDVGI=
 github.com/warthog618/go-gpiosim v0.1.0/go.mod h1:Ngx/LYI5toxHr4E+Vm6vTgCnt0of0tktsSuMUEJ2wCI=
-github.com/warthog618/gpiod v0.8.3 h1:hGFm/zf5PUyXU2LBG4fiZyRnbSSiPEajuOtQzQ3vkLo=
-github.com/warthog618/gpiod v0.8.3/go.mod h1:YHsKSpTHebSDGnKNQKfQp9t/0JxQCyXyYtCF3F+78dc=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/otel v1.34.0 h1:zRLXxLCgL1WyKsPVrgbSdMN4c0FMkDAskSTQP+0hdUY=

--- a/go.sum
+++ b/go.sum
@@ -34,10 +34,10 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/warthog618/go-gpiocdev v0.9.0 h1:AZWUq1WObgKCO9cJCACFpwWQw6yu8vJbIE6fRZ+6cbY=
-github.com/warthog618/go-gpiocdev v0.9.0/go.mod h1:GV4NZC82fWJERqk7Gu0+KfLSDIBEDNm6aPGiHlmT5fY=
-github.com/warthog618/go-gpiosim v0.1.0 h1:2rTMTcKUVZxpUuvRKsagnKAbKpd3Bwffp87xywEDVGI=
-github.com/warthog618/go-gpiosim v0.1.0/go.mod h1:Ngx/LYI5toxHr4E+Vm6vTgCnt0of0tktsSuMUEJ2wCI=
+github.com/warthog618/go-gpiocdev v0.9.1 h1:pwHPaqjJfhCipIQl78V+O3l9OKHivdRDdmgXYbmhuCI=
+github.com/warthog618/go-gpiocdev v0.9.1/go.mod h1:dN3e3t/S2aSNC+hgigGE/dBW8jE1ONk9bDSEYfoPyl8=
+github.com/warthog618/go-gpiosim v0.1.1 h1:MRAEv+T+itmw+3GeIGpQJBfanUVyg0l3JCTwHtwdre4=
+github.com/warthog618/go-gpiosim v0.1.1/go.mod h1:YXsnB+I9jdCMY4YAlMSRrlts25ltjmuIsrnoUrBLdqU=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/otel v1.34.0 h1:zRLXxLCgL1WyKsPVrgbSdMN4c0FMkDAskSTQP+0hdUY=

--- a/pkg/faces/base_provider.go
+++ b/pkg/faces/base_provider.go
@@ -495,6 +495,8 @@ func (bprv *BaseProvider) HandleRequest(start time.Time, prvReq *ProviderRequest
 	end := time.Now()
 	delta := end.Sub(start)
 
+	bprv.lastRequestTime = end
+
 	bprv.requestsTotal.WithLabelValues(bprv.Name, bprv.hostName, bprv.Key, fmt.Sprintf("%03d", resp.StatusCode)).Inc()
 	bprv.requestDuration.WithLabelValues(bprv.Name, bprv.hostName, bprv.Key).Observe(delta.Seconds())
 

--- a/pkg/faces/base_provider.go
+++ b/pkg/faces/base_provider.go
@@ -147,11 +147,17 @@ type ProviderInterface interface {
 type HTTPGetHandler func(w http.ResponseWriter, r *http.Request)
 type ProviderGetHandler func(prvReq *ProviderRequest) ProviderResponse
 
-// A Hook is a function that takes a ProviderRequest and a BaseRequestStatus and
-// returns a boolean indicating whether the request should proceed. If desired,
-// the Hook may modify the BaseRequestStatus in place to set the status code and
-// a message to hand back to the client.
-type Hook func(*BaseProvider, *ProviderRequest, *BaseRequestStatus) bool
+// A ProviderUpdater is a function that updates the provider's state based on external
+// things. It does _not_ get to short-circuit the request; it only gets to update
+// state.
+type ProviderUpdater func(*BaseProvider)
+
+// A ProviderHook is a function that takes a ProviderRequest and a
+// BaseRequestStatus and returns a boolean indicating whether the request
+// should proceed. If desired, the ProviderHook may modify the
+// BaseRequestStatus in place to set the status code and a message to hand
+// back to the client.
+type ProviderHook func(*BaseProvider, *ProviderRequest, *BaseRequestStatus) bool
 
 type BaseProvider struct {
 	Name               string // Name of this kind of provider
@@ -169,8 +175,9 @@ type BaseProvider struct {
 	providerGetHandler ProviderGetHandler
 	httpGetHandler     HTTPGetHandler
 
-	preHook  Hook
-	postHook Hook
+	updater  ProviderUpdater
+	preHook  ProviderHook
+	postHook ProviderHook
 
 	requestsTotal   *prometheus.CounterVec
 	requestDuration *prometheus.HistogramVec
@@ -267,11 +274,15 @@ func (bprv *BaseProvider) SetHTTPGetHandler(handler HTTPGetHandler) {
 	bprv.httpGetHandler = handler
 }
 
-func (bprv *BaseProvider) SetPreHook(hook Hook) {
+func (bprv *BaseProvider) SetUpdater(updater ProviderUpdater) {
+	bprv.updater = updater
+}
+
+func (bprv *BaseProvider) SetPreHook(hook ProviderHook) {
 	bprv.preHook = hook
 }
 
-func (bprv *BaseProvider) SetPostHook(hook Hook) {
+func (bprv *BaseProvider) SetPostHook(hook ProviderHook) {
 	bprv.postHook = hook
 }
 
@@ -423,6 +434,11 @@ func (bprv *BaseProvider) HandleRequest(start time.Time, prvReq *ProviderRequest
 	resp := ProviderResponseEmpty()
 
 	bprv.CheckUnlatch(start)
+
+	if bprv.updater != nil {
+		bprv.updater(bprv)
+	}
+
 	rstat := bprv.CheckRequestStatus()
 
 	if bprv.preHook != nil {

--- a/pkg/raspberry_pi/button.go
+++ b/pkg/raspberry_pi/button.go
@@ -20,7 +20,7 @@ package raspberry_pi
 import (
 	"time"
 
-	"github.com/warthog618/gpiod"
+	"github.com/warthog618/go-gpiocdev"
 )
 
 type ButtonEvent struct {
@@ -32,13 +32,13 @@ type ButtonEvent struct {
 type Button struct {
 	Name       string
 	Debounce   time.Duration
-	Line       *gpiod.Line
+	Line       *gpiocdev.Line
 	PressCount int
 
 	btnChan   chan ButtonEvent
-	evtChan   chan gpiod.LineEvent
+	evtChan   chan gpiocdev.LineEvent
 	state     int
-	lastEvent gpiod.LineEvent
+	lastEvent gpiocdev.LineEvent
 }
 
 func NewButton(chip string, pin int, debounce time.Duration, name string, btnChan chan ButtonEvent) (*Button, error) {
@@ -48,14 +48,14 @@ func NewButton(chip string, pin int, debounce time.Duration, name string, btnCha
 		PressCount: 0,
 		state:      0,
 		btnChan:    btnChan,
-		evtChan:    make(chan gpiod.LineEvent),
-		lastEvent: gpiod.LineEvent{
-			Type: gpiod.LineEventRisingEdge,
+		evtChan:    make(chan gpiocdev.LineEvent),
+		lastEvent: gpiocdev.LineEvent{
+			Type: gpiocdev.LineEventRisingEdge,
 		},
 	}
 
-	line, err := gpiod.RequestLine(chip, pin, gpiod.WithBothEdges, gpiod.WithPullDown,
-		gpiod.WithEventHandler(func(evt gpiod.LineEvent) {
+	line, err := gpiocdev.RequestLine(chip, pin, gpiocdev.WithBothEdges, gpiocdev.WithPullDown,
+		gpiocdev.WithEventHandler(func(evt gpiocdev.LineEvent) {
 			btn.evtChan <- evt
 		}))
 
@@ -74,7 +74,7 @@ func (btn *Button) Close() {
 }
 
 func (btn *Button) watch() {
-	events := make([]gpiod.LineEvent, 0, 2)
+	events := make([]gpiocdev.LineEvent, 0, 2)
 
 	// Wait for button presses
 	for {
@@ -83,14 +83,14 @@ func (btn *Button) watch() {
 			if btn.lastEvent.Type == evt.Type {
 				// Insert an event of the other type, 'cause we can't
 				// get two of the same edge in a row!
-				if evt.Type == gpiod.LineEventRisingEdge {
-					events = append(events, gpiod.LineEvent{
-						Type:      gpiod.LineEventFallingEdge,
+				if evt.Type == gpiocdev.LineEventRisingEdge {
+					events = append(events, gpiocdev.LineEvent{
+						Type:      gpiocdev.LineEventFallingEdge,
 						Timestamp: evt.Timestamp,
 					})
 				} else {
-					events = append(events, gpiod.LineEvent{
-						Type:      gpiod.LineEventRisingEdge,
+					events = append(events, gpiocdev.LineEvent{
+						Type:      gpiocdev.LineEventRisingEdge,
 						Timestamp: evt.Timestamp,
 					})
 				}
@@ -102,7 +102,7 @@ func (btn *Button) watch() {
 				delta := evt.Timestamp - btn.lastEvent.Timestamp
 				btn.lastEvent = evt
 
-				fallingEdge := (evt.Type == gpiod.LineEventFallingEdge)
+				fallingEdge := (evt.Type == gpiocdev.LineEventFallingEdge)
 
 				// edge := "UP"
 

--- a/pkg/raspberry_pi/hw.go
+++ b/pkg/raspberry_pi/hw.go
@@ -170,7 +170,7 @@ func (hw *HardwareStuff) Watch(startingErrorFraction int, startingLatched bool) 
 
 			hw.serverErrorFraction = efrac
 
-			fmt.Printf("hardware: error fraction now %d\n", hw.serverErrorFraction)
+			hw.Infof("error fraction now %d\n", hw.serverErrorFraction)
 		}
 	}()
 
@@ -180,7 +180,7 @@ func (hw *HardwareStuff) Watch(startingErrorFraction int, startingLatched bool) 
 
 			hw.serverLatched = !hw.serverLatched
 
-			fmt.Printf("hardware: latched now %v\n", hw.serverLatched)
+			hw.Infof("hardware: latched now %v\n", hw.serverLatched)
 		}
 	}()
 }
@@ -191,12 +191,12 @@ func (hw *HardwareStuff) Updater(bprv *faces.BaseProvider) {
 
 	if bprv.ErrorFraction() != hw.serverErrorFraction {
 		bprv.SetErrorFraction(hw.serverErrorFraction)
-		bprv.Infof("errorFraction %d", bprv.ErrorFraction())
+		bprv.Infof("Updater: set errorFraction to %d", bprv.ErrorFraction())
 	}
 
 	if bprv.IsLatched() != hw.serverLatched {
 		bprv.SetLatched(hw.serverLatched)
-		bprv.Infof("latched %v", bprv.IsLatched())
+		bprv.Infof("Updater: set latched to %v", bprv.IsLatched())
 	}
 }
 

--- a/pkg/raspberry_pi/hw.go
+++ b/pkg/raspberry_pi/hw.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/BuoyantIO/faces-demo/v2/pkg/faces"
 	"github.com/BuoyantIO/faces-demo/v2/pkg/utils"
-	"github.com/warthog618/gpiod"
+	"github.com/warthog618/go-gpiocdev"
 )
 
 type HardwareStuff struct {
@@ -38,7 +38,7 @@ type HardwareStuff struct {
 	button *Button
 	rotary *RotaryEncoder
 
-	leds map[string]*gpiod.Line
+	leds map[string]*gpiocdev.Line
 
 	btnChan    chan ButtonEvent
 	rotaryChan chan RotaryEvent
@@ -73,7 +73,7 @@ func NewHardwareStuff(rotaryAPin, rotaryBPin, buttonPin, ledGreenPin, ledRedPin 
 		return nil, fmt.Errorf("could not create rotary encoder on lines %d and %d: %s", rotaryAPin, rotaryBPin, err)
 	}
 
-	redLED, err := gpiod.RequestLine("gpiochip0", ledRedPin, gpiod.AsOutput(1), gpiod.LineDrivePushPull)
+	redLED, err := gpiocdev.RequestLine("gpiochip0", ledRedPin, gpiocdev.AsOutput(1), gpiocdev.LineDrivePushPull)
 
 	if err != nil {
 		btn.Close()
@@ -82,7 +82,7 @@ func NewHardwareStuff(rotaryAPin, rotaryBPin, buttonPin, ledGreenPin, ledRedPin 
 		return nil, fmt.Errorf("could not create red LED on line %d: %s", ledRedPin, err)
 	}
 
-	greenLED, err := gpiod.RequestLine("gpiochip0", ledGreenPin, gpiod.AsOutput(1), gpiod.LineDrivePushPull)
+	greenLED, err := gpiocdev.RequestLine("gpiochip0", ledGreenPin, gpiocdev.AsOutput(1), gpiocdev.LineDrivePushPull)
 
 	if err != nil {
 		btn.Close()
@@ -103,7 +103,7 @@ func NewHardwareStuff(rotaryAPin, rotaryBPin, buttonPin, ledGreenPin, ledRedPin 
 
 		button: btn,
 		rotary: rotary,
-		leds: map[string]*gpiod.Line{
+		leds: map[string]*gpiocdev.Line{
 			"red":   redLED,
 			"green": greenLED,
 		},

--- a/pkg/raspberry_pi/hw.go
+++ b/pkg/raspberry_pi/hw.go
@@ -185,7 +185,7 @@ func (hw *HardwareStuff) Watch(startingErrorFraction int, startingLatched bool) 
 	}()
 }
 
-func (hw *HardwareStuff) PreHook(bprv *faces.BaseProvider, prvReq *faces.ProviderRequest, rstat *faces.BaseRequestStatus) bool {
+func (hw *HardwareStuff) Updater(bprv *faces.BaseProvider) {
 	bprv.Lock()
 	defer bprv.Unlock()
 
@@ -198,7 +198,9 @@ func (hw *HardwareStuff) PreHook(bprv *faces.BaseProvider, prvReq *faces.Provide
 		bprv.SetLatched(hw.serverLatched)
 		bprv.Infof("latched %v", bprv.IsLatched())
 	}
+}
 
+func (hw *HardwareStuff) PreHook(bprv *faces.BaseProvider, prvReq *faces.ProviderRequest, rstat *faces.BaseRequestStatus) bool {
 	if rstat.IsErrored() || rstat.IsRateLimited() {
 		hw.ledOn("red")
 	} else {

--- a/pkg/raspberry_pi/rotary.go
+++ b/pkg/raspberry_pi/rotary.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/warthog618/gpiod"
+	"github.com/warthog618/go-gpiocdev"
 )
 
 type RotaryEvent struct {
@@ -43,8 +43,8 @@ type rotaryDebugEvent struct {
 type RotaryEncoder struct {
 	Name     string
 	Debounce time.Duration
-	LineA    *gpiod.Line
-	LineB    *gpiod.Line
+	LineA    *gpiocdev.Line
+	LineB    *gpiocdev.Line
 	Position int
 
 	Debug bool
@@ -52,7 +52,7 @@ type RotaryEncoder struct {
 	lock sync.Mutex
 
 	evtChan       chan RotaryEvent
-	gpioChan      chan gpiod.LineEvent
+	gpioChan      chan gpiocdev.LineEvent
 	debounceChan  chan interface{}
 	debounceTimer *time.Timer
 	state         int
@@ -70,13 +70,13 @@ func NewRotaryEncoder(chip string, pinA int, pinB int, debounce time.Duration, n
 		state:        3, // Assume we're starting with the knob stationary with both pins high.
 		evtChan:      evtChan,
 		debounceChan: make(chan interface{}),
-		gpioChan:     make(chan gpiod.LineEvent),
+		gpioChan:     make(chan gpiocdev.LineEvent),
 
 		debugEvents: make([]rotaryDebugEvent, 0, 10),
 	}
 
-	lineA, err := gpiod.RequestLine(chip, pinA, gpiod.WithBothEdges, gpiod.WithPullUp,
-		gpiod.WithEventHandler(func(evt gpiod.LineEvent) {
+	lineA, err := gpiocdev.RequestLine(chip, pinA, gpiocdev.WithBothEdges, gpiocdev.WithPullUp,
+		gpiocdev.WithEventHandler(func(evt gpiocdev.LineEvent) {
 			enc.gpioChan <- evt
 		}))
 
@@ -84,8 +84,8 @@ func NewRotaryEncoder(chip string, pinA int, pinB int, debounce time.Duration, n
 		return nil, err
 	}
 
-	lineB, err := gpiod.RequestLine(chip, pinB, gpiod.WithBothEdges, gpiod.WithPullUp,
-		gpiod.WithEventHandler(func(evt gpiod.LineEvent) {
+	lineB, err := gpiocdev.RequestLine(chip, pinB, gpiocdev.WithBothEdges, gpiocdev.WithPullUp,
+		gpiocdev.WithEventHandler(func(evt gpiocdev.LineEvent) {
 			enc.gpioChan <- evt
 		}))
 


### PR DESCRIPTION
Switch the GPIO library to its new name of `go-gpiocdev` and update it to version 0.9.1... then fix the bug that was preventing the Pi hardware from properly handling latching. 🤦‍♂️ 