### PR TITLE
Allow setting replica count and basic affinity/antiaffinity.

### DIFF
--- a/faces-chart/templates/_backend.yaml
+++ b/faces-chart/templates/_backend.yaml
@@ -75,11 +75,15 @@ metadata:
   name: {{ .name | quote }}
   namespace: {{ .root.Release.Namespace }}
   labels:
-    service: {{ .name | quote }}
+    buoyant.io/application: faces
+    faces.buoyant.io/component-type: backend
+    faces.buoyant.io/component: {{ .name | quote }}
 spec:
   type: ClusterIP
   selector:
-    service: {{ .name | quote }}
+    buoyant.io/application: faces
+    faces.buoyant.io/component-type: backend
+    faces.buoyant.io/component: {{ .name | quote }}
   ports:
   - port: 80
     targetPort: http
@@ -90,16 +94,22 @@ metadata:
   name: {{ .name | quote }}
   namespace: {{ .root.Release.Namespace }}
   labels:
-    service: {{ .name | quote }}
+    buoyant.io/application: faces
+    faces.buoyant.io/component-type: backend
+    faces.buoyant.io/component: {{ .name | quote }}
 spec:
   replicas: {{ include "partials.backend-replicas" (dict "root" .root "which" .name) }}
   selector:
     matchLabels:
-      service: {{ .name | quote }}
+      buoyant.io/application: faces
+      faces.buoyant.io/component-type: backend
+      faces.buoyant.io/component: {{ .name | quote }}
   template:
     metadata:
       labels:
-        service: {{ .name | quote }}
+        buoyant.io/application: faces
+        faces.buoyant.io/component-type: backend
+        faces.buoyant.io/component: {{ .name | quote }}
     spec:
       {{ include "partials.backend-affinityclause" (dict "root" .root "which" .name) }}
       containers:

--- a/faces-chart/templates/_backend.yaml
+++ b/faces-chart/templates/_backend.yaml
@@ -21,6 +21,13 @@
 {{- end -}}
 
 # params: .root for the root, .which for the name of the workload
+{{- define "partials.backend-replicas" -}}
+  {{- $source := index .root.Values .which -}}
+  {{- include "partials.select-key"
+      (dict "root" .root "source" $source "key" "replicas" "default" .root.Values.backend) -}}
+{{- end -}}
+
+# params: .root for the root, .which for the name of the workload
 {{- define "partials.backend-delayBuckets" -}}
   {{- $source := index .root.Values .which -}}
   {{- include "partials.select-env"
@@ -40,6 +47,17 @@
             "key" "errorFraction"
             "name" "ERROR_FRACTION"
             "default" .root.Values.backend) -}}
+{{- end -}}
+
+# params: .root for the root, .which for the name of the workload
+{{- define "partials.backend-affinityclause" -}}
+  {{- $source := index .root.Values .which -}}
+  {{- $antiaffinity := (default .root.Values.backend.antiaffinity $source.antiaffinity) }}
+  {{- $affinity := (default .root.Values.backend.affinity $source.affinity) }}
+  {{- include "partials.affinityclause"
+      (dict "antiaffinity" $antiaffinity
+            "affinity" $affinity
+            "which" .which) -}}
 {{- end -}}
 
 # partials.backend does all the heavy lifting for a backend workload
@@ -74,7 +92,7 @@ metadata:
   labels:
     service: {{ .name | quote }}
 spec:
-  replicas: 1
+  replicas: {{ include "partials.backend-replicas" (dict "root" .root "which" .name) }}
   selector:
     matchLabels:
       service: {{ .name | quote }}
@@ -83,6 +101,7 @@ spec:
       labels:
         service: {{ .name | quote }}
     spec:
+      {{ include "partials.backend-affinityclause" (dict "root" .root "which" .name) }}
       containers:
       - name: {{ .name | quote }}
         image: {{ include "partials.backend-image" (dict "root" .root "which" .name) }}

--- a/faces-chart/templates/_backend.yaml
+++ b/faces-chart/templates/_backend.yaml
@@ -66,6 +66,7 @@
 # for .name, but .workload would still be "color" in that case.
 {{- define "partials.backend" -}}
 {{- $info := index .root.Values .name -}}
+{{- $portname := (default "http" .portname ) -}}
 {{- if $info -}}
 {{- if $info.enabled }}
 ---
@@ -86,6 +87,7 @@ spec:
     faces.buoyant.io/component: {{ .name | quote }}
   ports:
   - port: 80
+    name: {{ $portname }}
     targetPort: http
 ---
 apiVersion: apps/v1

--- a/faces-chart/templates/_frontend.yaml
+++ b/faces-chart/templates/_frontend.yaml
@@ -22,6 +22,15 @@
 {{- end -}}
 
 # params: .root for the root, .which for the name of the workload
+{{- define "partials.frontend-replicas" -}}
+  {{- $source := index .root.Values .which -}}
+  {{- include "partials.select-key"
+      (dict "root" .root
+            "source" $source
+            "key" "replicas") -}}
+{{- end -}}
+
+# params: .root for the root, .which for the name of the workload
 {{- define "partials.frontend-delayBuckets" -}}
   {{- $source := index .root.Values .which -}}
   {{- include "partials.select-env"
@@ -41,6 +50,15 @@
             "name" "ERROR_FRACTION") -}}
 {{- end -}}
 
+# params: .root for the root, .which for the name of the workload
+{{- define "partials.frontend-affinityclause" -}}
+  {{- $source := index .root.Values .which -}}
+  {{- include "partials.affinityclause"
+      (dict ".antiaffinity" $source.antiaffinity
+            ".affinity" $source.affinity
+            "which" .which) -}}
+{{- end -}}
+
 # We use all the above to provide nicer helpers for each of the workloads.
 # Given that the frontend workloads are all different enough that it's not
 # worth having the equivalent of partials-backend, we need to include a lot
@@ -58,6 +76,18 @@
             "which" "gui") -}}
 {{- end -}}
 
+{{- define "partials.gui-replicas" -}}
+  {{- include "partials.frontend-replicas"
+      (dict "root" .
+            "which" "gui") -}}
+{{- end -}}
+
+{{- define "partials.gui-affinityclause" -}}
+  {{- include "partials.frontend-affinityclause"
+      (dict "root" .
+            "which" "gui") -}}
+{{- end -}}
+
 {{- define "partials.face-image" -}}
   {{- include "partials.frontend-image"
       (dict "root" .
@@ -66,6 +96,18 @@
 
 {{- define "partials.face-imagePullPolicy" -}}
   {{- include "partials.frontend-imagePullPolicy"
+      (dict "root" .
+            "which" "face") -}}
+{{- end -}}
+
+{{- define "partials.face-replicas" -}}
+  {{- include "partials.frontend-replicas"
+      (dict "root" .
+            "which" "face") -}}
+{{- end -}}
+
+{{- define "partials.face-affinityclause" -}}
+  {{- include "partials.frontend-affinityclause"
       (dict "root" .
             "which" "face") -}}
 {{- end -}}

--- a/faces-chart/templates/_helpers.tpl
+++ b/faces-chart/templates/_helpers.tpl
@@ -73,3 +73,42 @@
           value: {{ $value | quote }}
   {{ end -}}
 {{- end -}}
+
+# params: .antiaffinity, .affinity, .which
+{{- define "partials.affinityclause" -}}
+  {{- if (or .antiaffinity .affinity) -}}
+      affinity:
+        {{- if .antiaffinity }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: faces.buoyant.io/component
+                  operator: In
+                  values:
+                  - {{ .which | quote }}
+              topologyKey: kubernetes.io/hostname
+          - weight: 50
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: buoyant.io/application
+                  operator: In
+                  values:
+                  - faces
+              topologyKey: kubernetes.io/hostname
+        {{- end -}}
+        {{- if .affinity }}
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: {{ .affinity.key | quote }}
+                  operator: In
+                  values:
+                  - {{ .affinity.value | quote }}
+        {{- end -}}
+  {{- end -}}
+{{- end -}}

--- a/faces-chart/templates/color.yaml
+++ b/faces-chart/templates/color.yaml
@@ -1,12 +1,15 @@
 {{- include "partials.backend"
     (dict "name" "color"
           "workload" "color"
+          "portname" "http2"
           "root" .) }}
 {{- include "partials.backend"
     (dict "name" "color2"
           "workload" "color"
+          "portname" "http2"
           "root" .) }}
 {{- include "partials.backend"
     (dict "name" "color3"
           "workload" "color"
+          "portname" "http2"
           "root" .) }}

--- a/faces-chart/templates/face.yaml
+++ b/faces-chart/templates/face.yaml
@@ -26,7 +26,7 @@ metadata:
   labels:
     service: {{ $name }}
 spec:
-  replicas: 1
+  replicas: {{ include "partials.face-replicas" . }}
   selector:
     matchLabels:
       service: {{ $name }}
@@ -35,6 +35,7 @@ spec:
       labels:
         service: {{ $name }}
     spec:
+      {{ include "partials.face-affinityclause" . }}
       containers:
       - name: {{ $name }}
         image: {{ include "partials.face-image" . }}

--- a/faces-chart/templates/face.yaml
+++ b/faces-chart/templates/face.yaml
@@ -20,6 +20,7 @@ spec:
     faces.buoyant.io/component: {{ $name | quote }}
   ports:
   - port: 80
+    name: http
     targetPort: http
 ---
 apiVersion: apps/v1

--- a/faces-chart/templates/face.yaml
+++ b/faces-chart/templates/face.yaml
@@ -9,11 +9,15 @@ metadata:
   name: {{ $name }}
   namespace: {{ .Release.Namespace }}
   labels:
-    service: {{ $name }}
+    buoyant.io/application: faces
+    faces.buoyant.io/component-type: edge
+    faces.buoyant.io/component: {{ $name | quote }}
 spec:
   type: ClusterIP
   selector:
-    service: {{ $name }}
+    buoyant.io/application: faces
+    faces.buoyant.io/component-type: edge
+    faces.buoyant.io/component: {{ $name | quote }}
   ports:
   - port: 80
     targetPort: http
@@ -24,16 +28,22 @@ metadata:
   name: {{ $name }}
   namespace: {{ .Release.Namespace }}
   labels:
-    service: {{ $name }}
+    buoyant.io/application: faces
+    faces.buoyant.io/component-type: edge
+    faces.buoyant.io/component: {{ $name | quote }}
 spec:
   replicas: {{ include "partials.face-replicas" . }}
   selector:
     matchLabels:
-      service: {{ $name }}
+      buoyant.io/application: faces
+      faces.buoyant.io/component-type: edge
+      faces.buoyant.io/component: {{ $name | quote }}
   template:
     metadata:
       labels:
-        service: {{ $name }}
+        buoyant.io/application: faces
+        faces.buoyant.io/component-type: edge
+        faces.buoyant.io/component: {{ $name | quote }}
     spec:
       {{ include "partials.face-affinityclause" . }}
       containers:

--- a/faces-chart/templates/faces-gui.yaml
+++ b/faces-chart/templates/faces-gui.yaml
@@ -26,7 +26,7 @@ metadata:
   labels:
     service: faces-gui
 spec:
-  replicas: 1
+  replicas: {{ include "partials.gui-replicas" . }}
   selector:
     matchLabels:
       service: faces-gui
@@ -35,6 +35,7 @@ spec:
       labels:
         service: faces-gui
     spec:
+      {{ include "partials.gui-affinityclause" . }}
       containers:
       - name: faces-gui
         image: {{ include "partials.gui-image" . }}

--- a/faces-chart/templates/faces-gui.yaml
+++ b/faces-chart/templates/faces-gui.yaml
@@ -9,11 +9,15 @@ metadata:
   name: faces-gui
   namespace: {{ .Release.Namespace }}
   labels:
-    service: faces-gui
+    buoyant.io/application: faces
+    faces.buoyant.io/component-type: frontend
+    faces.buoyant.io/component: faces-gui
 spec:
   type: {{ $serviceType }}
   selector:
-    service: faces-gui
+    buoyant.io/application: faces
+    faces.buoyant.io/component-type: frontend
+    faces.buoyant.io/component: faces-gui
   ports:
   - port: 80
     targetPort: http
@@ -24,16 +28,22 @@ metadata:
   name: faces-gui
   namespace: {{ .Release.Namespace }}
   labels:
-    service: faces-gui
+    buoyant.io/application: faces
+    faces.buoyant.io/component-type: frontend
+    faces.buoyant.io/component: faces-gui
 spec:
   replicas: {{ include "partials.gui-replicas" . }}
   selector:
     matchLabels:
-      service: faces-gui
+      buoyant.io/application: faces
+      faces.buoyant.io/component-type: frontend
+      faces.buoyant.io/component: faces-gui
   template:
     metadata:
       labels:
-        service: faces-gui
+        buoyant.io/application: faces
+        faces.buoyant.io/component-type: frontend
+        faces.buoyant.io/component: faces-gui
     spec:
       {{ include "partials.gui-affinityclause" . }}
       containers:

--- a/faces-chart/templates/faces-gui.yaml
+++ b/faces-chart/templates/faces-gui.yaml
@@ -20,6 +20,7 @@ spec:
     faces.buoyant.io/component: faces-gui
   ports:
   - port: 80
+    name: http
     targetPort: http
 ---
 apiVersion: apps/v1

--- a/faces-chart/templates/ingress.yaml
+++ b/faces-chart/templates/ingress.yaml
@@ -17,6 +17,7 @@ spec:
     faces.buoyant.io/component: faces-gui
   ports:
   - port: 80
+    name: http
     targetPort: http
 ---
 apiVersion: apps/v1

--- a/faces-chart/templates/ingress.yaml
+++ b/faces-chart/templates/ingress.yaml
@@ -6,11 +6,15 @@ metadata:
   name: face
   namespace: {{ .Release.Namespace }}
   labels:
-    service: face
+    buoyant.io/application: faces
+    faces.buoyant.io/component-type: edge
+    faces.buoyant.io/component: faces-gui
 spec:
   type: ClusterIP
   selector:
-    service: face
+    buoyant.io/application: faces
+    faces.buoyant.io/component-type: edge
+    faces.buoyant.io/component: faces-gui
   ports:
   - port: 80
     targetPort: http
@@ -21,16 +25,22 @@ metadata:
   name: face
   namespace: {{ .Release.Namespace }}
   labels:
-    service: face
+    buoyant.io/application: faces
+    faces.buoyant.io/component-type: edge
+    faces.buoyant.io/component: faces-gui
 spec:
   replicas: 1
   selector:
     matchLabels:
-      service: face
+      buoyant.io/application: faces
+      faces.buoyant.io/component-type: edge
+      faces.buoyant.io/component: faces-gui
   template:
     metadata:
       labels:
-        service: face
+        buoyant.io/application: faces
+        faces.buoyant.io/component-type: edge
+        faces.buoyant.io/component: faces-gui
     spec:
       containers:
       - name: face

--- a/faces-chart/values.yaml
+++ b/faces-chart/values.yaml
@@ -9,6 +9,9 @@ defaultImageTag: ""             # If not set, uses the appVersion
 # Default imagePullPolicy. This is used only if not set in the sections below.
 defaultImagePullPolicy: IfNotPresent
 
+# Default replica count. This is used only if not set in the sections below.
+defaultReplicas: 1
+
 # User auth header.
 authHeader: "X-Faces-User"
 


### PR DESCRIPTION
This follows the same basic rules as e.g. enabling a service, and it's pretty basic:

- `defaultReplicas` is the default replica count
- `$thing.antiaffinity=true` enables basic antiaffinity
- `$thing.affinity.key` and `$thing.affinity.value` set a key & value for Node values on which the thing must run

As always, you can set for individual workloads or for `backend` to get all the backends.

Also, labeling is different now: everything is labeled with

- `buoyant.io/application: faces`
- `faces.buoyant.io/component-type`: _frontend_, _backend_, or _edge_ (for `face`/`cell`)
- `faces.buoyant.io/component`: the name of the workload (`smiley`, `color`, `face`, etc.)

Signed-off-by: Flynn <flynn@buoyant.io>
