### PR TITLE
Temporarily drop limits (they'll be optional in 2.0.0 final)

### DIFF
--- a/faces-chart/templates/_backend.yaml
+++ b/faces-chart/templates/_backend.yaml
@@ -136,9 +136,9 @@ spec:
           requests:
             cpu: 100m
             memory: 64Mi
-          limits:
-            cpu: 250m
-            memory: 128Mi
+          # limits:
+          #   cpu: 250m
+          #   memory: 128Mi
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/faces-chart/templates/face.yaml
+++ b/faces-chart/templates/face.yaml
@@ -65,6 +65,6 @@ spec:
           requests:
             cpu: 300m     # The face service doesn't need much memory, but it does need more
             memory: 64Mi  # CPU than the other backend services since it has to call the
-          limits:         # face and smiley services, then composite the results.
-            cpu: 500m
-            memory: 128Mi
+          # limits:         # face and smiley services, then composite the results.
+          #   cpu: 500m
+          #   memory: 128Mi

--- a/faces-chart/templates/faces-gui.yaml
+++ b/faces-chart/templates/faces-gui.yaml
@@ -61,6 +61,6 @@ spec:
           requests:
             cpu: 50m
             memory: 64Mi
-          limits:
-            cpu: 100m
-            memory: 128Mi
+          # limits:
+          #   cpu: 100m
+          #   memory: 128Mi

--- a/faces-chart/templates/ingress.yaml
+++ b/faces-chart/templates/ingress.yaml
@@ -61,7 +61,7 @@ spec:
           requests:
             cpu: 100m
             memory: 64Mi
-          limits:
-            cpu: 250m
-            memory: 128Mi
+          # limits:
+          #   cpu: 250m
+          #   memory: 128Mi
 {{- end -}}


### PR DESCRIPTION
The limits should be optional. For now, I'm removing them.

Signed-off-by: Flynn <flynn@buoyant.io>
