### PR TITLE
Clean up the chart for 2.0.0 final

### DIFF
--- a/faces-chart/templates/_backend.yaml
+++ b/faces-chart/templates/_backend.yaml
@@ -14,20 +14,6 @@
 {{- end -}}
 
 # params: .root for the root, .which for the name of the workload
-{{- define "partials.backend-imagePullPolicy" -}}
-  {{- $source := index .root.Values .which -}}
-  {{- include "partials.select-key"
-      (dict "root" .root "source" $source "key" "imagePullPolicy" "default" .root.Values.backend) -}}
-{{- end -}}
-
-# params: .root for the root, .which for the name of the workload
-{{- define "partials.backend-replicas" -}}
-  {{- $source := index .root.Values .which -}}
-  {{- include "partials.select-key"
-      (dict "root" .root "source" $source "key" "replicas" "default" .root.Values.backend) -}}
-{{- end -}}
-
-# params: .root for the root, .which for the name of the workload
 {{- define "partials.backend-delayBuckets" -}}
   {{- $source := index .root.Values .which -}}
   {{- include "partials.select-env"
@@ -113,7 +99,9 @@ metadata:
     faces.buoyant.io/component-type: backend
     faces.buoyant.io/component: {{ .name | quote }}
 spec:
-  replicas: {{ include "partials.backend-replicas" (dict "root" .root "which" .name) }}
+  replicas: {{ get $info "replicas"
+                | default (.root.Values.backend).replicas
+                | default (.root.Values).defaultReplicas }}
   selector:
     matchLabels:
       buoyant.io/application: faces
@@ -130,7 +118,9 @@ spec:
       containers:
       - name: {{ .name | quote }}
         image: {{ include "partials.backend-image" (dict "root" .root "which" .name) }}
-        imagePullPolicy: {{ include "partials.backend-imagePullPolicy" (dict "root" .root "which" .name) }}
+        imagePullPolicy: {{ get $info "imagePullPolicy"
+                            | default (.root.Values.backend).imagePullPolicy
+                            | default (.root.Values).defaultImagePullPolicy }}
         ports:
         - name: http
           containerPort: 8000

--- a/faces-chart/templates/_backend.yaml
+++ b/faces-chart/templates/_backend.yaml
@@ -39,6 +39,19 @@
 {{- end -}}
 
 # params: .root for the root, .which for the name of the workload
+{{- define "partials.backend-resources" -}}
+  {{- $source := index .root.Values .which -}}
+  {{- $requests := get $source "requests"
+                   | default (.root.Values.backend).requests
+                   | default (.root.Values).defaultRequests -}}
+  {{- $limits := get $source "limits"
+                 | default (.root.Values.backend).limits
+                 | default (.root.Values).defaultLimits -}}
+  {{- include "partials.resources" (dict "requests" $requests
+                                        "limits" $limits) }}
+{{- end -}}
+
+# params: .root for the root, .which for the name of the workload
 {{- define "partials.backend-errorFraction" -}}
   {{- $source := index .root.Values .which -}}
   {{- include "partials.select-env"
@@ -132,13 +145,7 @@ spec:
         {{- end -}}
         {{- include "partials.backend-delayBuckets" (dict "root" .root "which" .name) }}
         {{- include "partials.backend-errorFraction" (dict "root" .root "which" .name) }}
-        resources:
-          requests:
-            cpu: 100m
-            memory: 64Mi
-          # limits:
-          #   cpu: 250m
-          #   memory: 128Mi
+        {{ include "partials.backend-resources" (dict "root" .root "which" .name) }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/faces-chart/templates/_frontend.yaml
+++ b/faces-chart/templates/_frontend.yaml
@@ -111,6 +111,12 @@
             "which" "ingress") -}}
 {{- end -}}
 
+{{- define "partials.ingress-affinityclause" -}}
+  {{- include "partials.frontend-affinityclause"
+      (dict "root" .
+            "which" "ingress") -}}
+{{- end -}}
+
 {{- define "partials.ingress-resources" -}}
   {{- include "partials.frontend-resources"
       (dict "root" .

--- a/faces-chart/templates/_frontend.yaml
+++ b/faces-chart/templates/_frontend.yaml
@@ -59,6 +59,17 @@
             "which" .which) -}}
 {{- end -}}
 
+# params: .root for the root, .which for the name of the workload
+{{- define "partials.frontend-resources" -}}
+  {{- $source := index .root.Values .which -}}
+  {{- $requests := get $source "requests"
+                   | default (.root.Values).defaultRequests -}}
+  {{- $limits := get $source "limits"
+                 | default (.root.Values).defaultLimits -}}
+  {{- include "partials.resources" (dict "requests" $requests
+                                        "limits" $limits) }}
+{{- end -}}
+
 # We use all the above to provide nicer helpers for each of the workloads.
 # Given that the frontend workloads are all different enough that it's not
 # worth having the equivalent of partials-backend, we need to include a lot
@@ -88,6 +99,12 @@
             "which" "gui") -}}
 {{- end -}}
 
+{{- define "partials.gui-resources" -}}
+  {{- include "partials.frontend-resources"
+      (dict "root" .
+            "which" "gui") -}}
+{{- end -}}
+
 {{- define "partials.face-image" -}}
   {{- include "partials.frontend-image"
       (dict "root" .
@@ -112,6 +129,12 @@
             "which" "face") -}}
 {{- end -}}
 
+{{- define "partials.face-resources" -}}
+  {{- include "partials.frontend-resources"
+      (dict "root" .
+            "which" "face") -}}
+{{- end -}}
+
 {{- define "partials.face-delayBuckets" -}}
   {{- include "partials.frontend-delayBuckets"
       (dict "root" .
@@ -132,6 +155,12 @@
 
 {{- define "partials.ingress-imagePullPolicy" -}}
   {{- include "partials.frontend-imagePullPolicy"
+      (dict "root" .
+            "which" "ingress") -}}
+{{- end -}}
+
+{{- define "partials.ingress-resources" -}}
+  {{- include "partials.frontend-resources"
       (dict "root" .
             "which" "ingress") -}}
 {{- end -}}

--- a/faces-chart/templates/_frontend.yaml
+++ b/faces-chart/templates/_frontend.yaml
@@ -13,24 +13,6 @@
 {{- end -}}
 
 # params: .root for the root, .which for the name of the workload
-{{- define "partials.frontend-imagePullPolicy" -}}
-  {{- $source := index .root.Values .which -}}
-  {{- include "partials.select-key"
-      (dict "root" .root
-            "source" $source
-            "key" "imagePullPolicy") -}}
-{{- end -}}
-
-# params: .root for the root, .which for the name of the workload
-{{- define "partials.frontend-replicas" -}}
-  {{- $source := index .root.Values .which -}}
-  {{- include "partials.select-key"
-      (dict "root" .root
-            "source" $source
-            "key" "replicas") -}}
-{{- end -}}
-
-# params: .root for the root, .which for the name of the workload
 {{- define "partials.frontend-delayBuckets" -}}
   {{- $source := index .root.Values .which -}}
   {{- include "partials.select-env"
@@ -81,18 +63,6 @@
             "which" "gui") -}}
 {{- end -}}
 
-{{- define "partials.gui-imagePullPolicy" -}}
-  {{- include "partials.frontend-imagePullPolicy"
-      (dict "root" .
-            "which" "gui") -}}
-{{- end -}}
-
-{{- define "partials.gui-replicas" -}}
-  {{- include "partials.frontend-replicas"
-      (dict "root" .
-            "which" "gui") -}}
-{{- end -}}
-
 {{- define "partials.gui-affinityclause" -}}
   {{- include "partials.frontend-affinityclause"
       (dict "root" .
@@ -107,18 +77,6 @@
 
 {{- define "partials.face-image" -}}
   {{- include "partials.frontend-image"
-      (dict "root" .
-            "which" "face") -}}
-{{- end -}}
-
-{{- define "partials.face-imagePullPolicy" -}}
-  {{- include "partials.frontend-imagePullPolicy"
-      (dict "root" .
-            "which" "face") -}}
-{{- end -}}
-
-{{- define "partials.face-replicas" -}}
-  {{- include "partials.frontend-replicas"
       (dict "root" .
             "which" "face") -}}
 {{- end -}}
@@ -149,12 +107,6 @@
 
 {{- define "partials.ingress-image" -}}
   {{- include "partials.frontend-image"
-      (dict "root" .
-            "which" "ingress") -}}
-{{- end -}}
-
-{{- define "partials.ingress-imagePullPolicy" -}}
-  {{- include "partials.frontend-imagePullPolicy"
       (dict "root" .
             "which" "ingress") -}}
 {{- end -}}

--- a/faces-chart/templates/_helpers.tpl
+++ b/faces-chart/templates/_helpers.tpl
@@ -112,3 +112,28 @@
         {{- end -}}
   {{- end -}}
 {{- end -}}
+
+# params: .requests and .limits
+{{- define "partials.resources" -}}
+  {{- if or .requests .limits }}
+        resources:
+          {{- if .requests }}
+          requests:
+            {{- if hasKey .requests "cpu" }}
+            cpu: {{ .requests.cpu | quote }}
+            {{- end }}
+            {{- if hasKey .requests "memory" }}
+            memory: {{ .requests.memory | quote }}
+            {{- end }}
+          {{- end }}
+          {{- if .limits }}
+          limits:
+            {{- if hasKey .limits "cpu" }}
+            cpu: {{ .limits.cpu | quote }}
+            {{- end }}
+            {{- if hasKey .limits "memory" }}
+            memory: {{ .limits.memory | quote }}
+            {{- end }}
+          {{- end }}
+  {{- end }}
+{{- end -}}

--- a/faces-chart/templates/face.yaml
+++ b/faces-chart/templates/face.yaml
@@ -61,6 +61,14 @@ spec:
           value: "face"
         - name: USER_HEADER_NAME
           value: {{ .Values.authHeader | quote }}
+        - name: SMILEY_SERVICE
+          value: {{ get .Values.face "smileyService"
+                    | default "smiley"
+                    | quote }}
+        - name: COLOR_SERVICE
+          value: {{ get .Values.face "colorService"
+                    | default "color"
+                    | quote }}
         {{- include "partials.face-errorFraction" . }}
         {{- include "partials.face-delayBuckets" . }}
         {{- include "partials.face-resources" . }}

--- a/faces-chart/templates/face.yaml
+++ b/faces-chart/templates/face.yaml
@@ -61,10 +61,4 @@ spec:
           value: {{ .Values.authHeader | quote }}
         {{- include "partials.face-errorFraction" . }}
         {{- include "partials.face-delayBuckets" . }}
-        resources:
-          requests:
-            cpu: 300m     # The face service doesn't need much memory, but it does need more
-            memory: 64Mi  # CPU than the other backend services since it has to call the
-          # limits:         # face and smiley services, then composite the results.
-          #   cpu: 500m
-          #   memory: 128Mi
+        {{- include "partials.face-resources" . }}

--- a/faces-chart/templates/face.yaml
+++ b/faces-chart/templates/face.yaml
@@ -33,7 +33,8 @@ metadata:
     faces.buoyant.io/component-type: edge
     faces.buoyant.io/component: {{ $name | quote }}
 spec:
-  replicas: {{ include "partials.face-replicas" . }}
+  replicas: {{ get .Values.face "replicas"
+               | default .Values.defaultReplicas }}
   selector:
     matchLabels:
       buoyant.io/application: faces
@@ -50,7 +51,8 @@ spec:
       containers:
       - name: {{ $name }}
         image: {{ include "partials.face-image" . }}
-        imagePullPolicy: {{ include "partials.face-imagePullPolicy" . }}
+        imagePullPolicy: {{ get .Values.face "imagePullPolicy"
+                            | default .Values.defaultImagePullPolicy }}
         ports:
         - name: http
           containerPort: 8000

--- a/faces-chart/templates/faces-gui.yaml
+++ b/faces-chart/templates/faces-gui.yaml
@@ -33,7 +33,8 @@ metadata:
     faces.buoyant.io/component-type: frontend
     faces.buoyant.io/component: faces-gui
 spec:
-  replicas: {{ include "partials.gui-replicas" . }}
+  replicas: {{ get .Values.gui "replicas"
+               | default .Values.defaultReplicas }}
   selector:
     matchLabels:
       buoyant.io/application: faces
@@ -50,7 +51,8 @@ spec:
       containers:
       - name: faces-gui
         image: {{ include "partials.gui-image" . }}
-        imagePullPolicy: {{ include "partials.gui-imagePullPolicy" . }}
+        imagePullPolicy: {{ get .Values.gui "imagePullPolicy"
+                            | default .Values.defaultImagePullPolicy }}
         env:
         - name: USER_HEADER_NAME
           value: {{ .Values.authHeader | quote }}

--- a/faces-chart/templates/faces-gui.yaml
+++ b/faces-chart/templates/faces-gui.yaml
@@ -57,10 +57,4 @@ spec:
         ports:
         - name: http
           containerPort: 8000
-        resources:
-          requests:
-            cpu: 50m
-            memory: 64Mi
-          # limits:
-          #   cpu: 100m
-          #   memory: 128Mi
+        {{- include "partials.gui-resources" . }}

--- a/faces-chart/templates/ingress.yaml
+++ b/faces-chart/templates/ingress.yaml
@@ -44,6 +44,7 @@ spec:
         faces.buoyant.io/component-type: edge
         faces.buoyant.io/component: faces-gui
     spec:
+      {{ include "partials.ingress-affinityclause" . }}
       containers:
       - name: face
         image: {{ include "partials.ingress-image" . }}

--- a/faces-chart/templates/ingress.yaml
+++ b/faces-chart/templates/ingress.yaml
@@ -30,7 +30,8 @@ metadata:
     faces.buoyant.io/component-type: edge
     faces.buoyant.io/component: faces-gui
 spec:
-  replicas: 1
+  replicas: {{ get .Values.ingress "replicas"
+               | default .Values.defaultReplicas }}
   selector:
     matchLabels:
       buoyant.io/application: faces
@@ -46,7 +47,8 @@ spec:
       containers:
       - name: face
         image: {{ include "partials.ingress-image" . }}
-        imagePullPolicy: {{ include "partials.ingress-imagePullPolicy" . }}
+        imagePullPolicy: {{ get .Values.ingress "imagePullPolicy"
+                            | default .Values.defaultImagePullPolicy }}
         ports:
         - name: http
           containerPort: 8000

--- a/faces-chart/templates/ingress.yaml
+++ b/faces-chart/templates/ingress.yaml
@@ -57,11 +57,5 @@ spec:
           value: {{ .Values.authHeader | quote }}
         - name: CELL_SERVICE
           value: {{ .Values.ingress.cellService | quote }}
-        resources:
-          requests:
-            cpu: 100m
-            memory: 64Mi
-          # limits:
-          #   cpu: 250m
-          #   memory: 128Mi
+        {{- include "partials.ingress-resources" . }}
 {{- end -}}

--- a/faces-chart/values.yaml
+++ b/faces-chart/values.yaml
@@ -29,6 +29,8 @@ face:
   imagePullPolicy: ""           # If not set, uses the default imagePullPolicy
   errorFraction: "20"
   delayBuckets: ""
+  # smileyService: smiley         # Override if desired
+  # colorService: color           # Override if desired
 
 ingress:
   enabled: False                # If set to True, enables the ingress workload


### PR DESCRIPTION
This is just a bunch of annoying cleanup that needed to happen for 2.0.0.

- **Parameterize resource requests and limits**
- **Drop imagePullPolicy and replicas partials (and correctly parameterize ingress.replicas)**
- **Parameterize ingress.affinityclause**
- **Parameterize face workload SMILEY_SERVICE and COLOR_SERVICE**
