### PR TITLE
Don't set the no-longer-needed FACES_SERVICE environment variable

### DIFF
--- a/Dockerfiles/Dockerfile.gui
+++ b/Dockerfiles/Dockerfile.gui
@@ -29,8 +29,5 @@ COPY gui-workload /workload
 # Also copy HTML files to be served.
 COPY assets/html /app/data
 
-# Default to the GUI service
-ENV FACES_SERVICE=gui
-
 # Set the entrypoint to the compiled binary
 ENTRYPOINT ["/workload"]

--- a/faces-chart/templates/_backend.yaml
+++ b/faces-chart/templates/_backend.yaml
@@ -125,8 +125,6 @@ spec:
         - name: http
           containerPort: 8000
         env:
-        - name: FACES_SERVICE
-          value: {{ .workload | quote }}
         - name: USER_HEADER_NAME
           value: {{ .root.Values.authHeader | quote }}
         {{- if index $info .workload }}

--- a/faces-chart/templates/face.yaml
+++ b/faces-chart/templates/face.yaml
@@ -57,8 +57,6 @@ spec:
         - name: http
           containerPort: 8000
         env:
-        - name: FACES_SERVICE
-          value: "face"
         - name: USER_HEADER_NAME
           value: {{ .Values.authHeader | quote }}
         - name: SMILEY_SERVICE

--- a/faces-chart/templates/ingress.yaml
+++ b/faces-chart/templates/ingress.yaml
@@ -54,8 +54,6 @@ spec:
         - name: http
           containerPort: 8000
         env:
-        - name: FACES_SERVICE
-          value: "ingress"
         - name: USER_HEADER_NAME
           value: {{ .Values.authHeader | quote }}
         - name: CELL_SERVICE


### PR DESCRIPTION
FACES_SERVICE has been pointless ever since the different commands got split into different binaries.

Signed-off-by: Flynn <flynn@buoyant.io>
